### PR TITLE
Updating kubectl rollout command

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -78,4 +78,4 @@ UPGRADE_COMMAND="${UPGRADE_COMMAND}"
 echo "Executing: ${UPGRADE_COMMAND}"
 ${UPGRADE_COMMAND}
 
-kubectl rollout status deployment/${DEPLOY_NAME}
+kubectl -n ${DEPLOY_NAMESPACE} rollout status deployment/${DEPLOY_NAME}


### PR DESCRIPTION
We are wanting to move away from deploying every application to the default namespace. AWS Sandbox currently deploys it's apps in their own dedicated namespace, so we now need to specify this flag in our kubectl rollout command for it to be found.